### PR TITLE
Fix #199: fix chat font for mobile browsers

### DIFF
--- a/static/app.css
+++ b/static/app.css
@@ -208,7 +208,8 @@ a.button {
 .chat>* {
     font-size: 0.7em;
     margin: 0;
-    font-family: cursive;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    line-height: 1.4;
     width: -webkit-fill-available;
     /* border: 1px solid; */
 }


### PR DESCRIPTION
- Replace the chat bubble font in from cursive to a mobile-friendly system sans-serif stack.
- This makes chat text more readable on phones and desktop without changing the rest of the app’s typography.
- The change is scoped to .chat>*, so only chat message content is affected.
